### PR TITLE
Fix arrow key navigation between steps

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,8 @@
       @scroll="handleScroll">
       <div
         class="intro"
-        tabindex="-1">
+        tabindex="-1"
+        @keyup.stop.prevent>
         <h1 class="title is-spaced">Algorithm Explorer</h1>
         <h2 class="subtitle">This framework explores machine learning techniques top down.</h2>
         <div class="content">
@@ -38,7 +39,6 @@
       </div>
       <div class="steps-container">
         <Step
-          tabindex="-1"
           v-for="(step, i) in steps"
           :key="i"
           :step="i + 1"
@@ -76,7 +76,7 @@
                 <button
                   class="button is-text"
                   tabindex="0"
-                  @keyup.enter="goToStep(currentStep - 1)"
+                  @keyup.enter.stop.prevent="goToStep(currentStep - 1)"
                   @click="goToStep(currentStep - 1)">
                   Go back
                 </button>
@@ -192,7 +192,7 @@ export default {
   /* ♻️ Lifecycle Hooks */
   created() {
     this.throttleHandleKeydown = throttle(this.handleKeydown, 500);
-    window.addEventListener('keydown', this.throttleHandleKeydown, true);
+    window.addEventListener('keydown', this.throttleHandleKeydown);
     window.addEventListener('resize', this.handelResize);
   },
   mounted() {
@@ -204,7 +204,7 @@ export default {
   },
 
   methods: {
-    /* Global Handlers */
+    /* 🌎 Global Handlers */
     handelResize() {
       if (!this.term) return;
       const activeTerm = document.querySelector('.vocab--active');
@@ -337,7 +337,8 @@ body,
 .scroller {
   position: relative;
   width: 100%;
-  height: calc(100% - #{$navigator-height});
+  height: 100%;
+  padding-bottom: $navigator-height;
   overflow: auto;
 }
 
@@ -353,7 +354,7 @@ body,
   display: flex;
   flex-flow: column nowrap;
   justify-content: center;
-  height: 100%;
+  min-height: 100%;
 }
 
 .start {

--- a/src/components/Navigator/Navigator.vue
+++ b/src/components/Navigator/Navigator.vue
@@ -64,10 +64,12 @@ export default {
 
 <style lang="scss" scoped>
 .navigator {
+  display: flex;
   position: fixed;
   right: 0;
   bottom: 0;
   left: 0;
+  align-items: center;
   height: $navigator-height;
   transform: translateY(100%);
   transition: all 0.45s;
@@ -80,17 +82,16 @@ export default {
 
 .navigator-container {
   display: flex;
+  flex: 1 1 auto;
   flex-flow: column nowrap;
   justify-content: center;
-  max-width: 800px;
   height: 100%;
-  margin: auto;
-  padding: 0 2rem;
+  margin: 0 1rem;
 }
 
 .progress {
   position: relative;
-  width: 200px;
+  max-width: 200px;
   height: 4px;
   overflow: hidden;
   border-radius: 12px;
@@ -114,11 +115,9 @@ export default {
 
 .controls {
   display: flex;
-  position: absolute;
-  top: 50%;
-  right: 1rem;
+  flex: 0 0 auto;
   align-items: center;
-  transform: translateY(-50%);
+  margin-right: 1rem;
   border: 1px solid rgba($light, 0.3);
   border-radius: 4px;
 }

--- a/src/components/Step/Step.vue
+++ b/src/components/Step/Step.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="step">
+  <div
+    class="step"
+    tabindex="-1"
+    @keyup.stop.prevent>
     <header v-if="title">
       <span class="step-number">{{ step }}. </span>
       <span


### PR DESCRIPTION
Changes
- Add present and stop propagation on keyup events for the Step component
- Allows default arrow scrolling to be disabled in favor of letting `goToStep` scroll to the proper step